### PR TITLE
fix: streamline documentation link handling and update related tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ci:release": "changeset publish",
     "ci:version": "changeset version && pnpm install --lockfile-only --engine-strict=false",
     "dev": "turbo run dev",
-    "format": "prettier --write . && biome format --write .",
+    "format": "prettier --write . && biome check --write .",
     "lint": "prettier --check . && biome check",
     "prepare": "husky",
     "test": "turbo run test"

--- a/packages/mcp-dev-assist/src/lib/mcp.ts
+++ b/packages/mcp-dev-assist/src/lib/mcp.ts
@@ -122,7 +122,9 @@ export const createServer = () => {
 			// read the first TOP_N results
 			const resultsWithMarkdown = await Promise.all(
 				searchResults.slice(0, TOP_N).map(async (result) => {
-					const markdown = await getDocumentationPageMarkdown(new URL(result.link));
+					const markdown = await getDocumentationPageMarkdown(
+						new URL(result.link),
+					);
 					return {
 						...result,
 						markdown,

--- a/packages/mcp-dev-assist/src/lib/read.ts
+++ b/packages/mcp-dev-assist/src/lib/read.ts
@@ -18,24 +18,7 @@ import * as cheerio from "cheerio";
 import { got, gotScraping } from "got-scraping";
 import { toMarkdown } from "./utils.js";
 
-export function getResourceUri(uri: URL): string {
-	// check if extension such as png, jpg, etc.
-	if (
-		["png", "jpg", "jpeg", "gif", "webp"].includes(
-			uri.pathname.split(".").pop()?.toLowerCase() ?? "",
-		)
-	) {
-		return uri.toString();
-	}
-
-	if (uri.hostname === "developers.google.com") {
-		return `docs://${uri.hostname}${uri.pathname}`;
-	}
-
-	return uri.toString();
-}
-
-export async function read(uri: URL): Promise<string> {
+export async function getDocumentationPageMarkdown(uri: URL): Promise<string> {
 	const mdUri = new URL(uri);
 	mdUri.pathname += ".md.txt";
 
@@ -68,7 +51,7 @@ export async function read(uri: URL): Promise<string> {
 	return markdown;
 }
 
-export async function releaseNotes(): Promise<
+export async function getReleaseNotes(): Promise<
 	{ updated: string; id: string; markdown: string }[]
 > {
 	const feeds = [

--- a/packages/mcp-dev-assist/src/lib/utils.test.ts
+++ b/packages/mcp-dev-assist/src/lib/utils.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { toMarkdown, toAbsoluteUrl } from "./utils.js";
+import { toAbsoluteUrl, toMarkdown } from "./utils.js";
 
 describe("toMarkdown", () => {
 	it("should convert html to markdown", async () => {

--- a/packages/mcp-dev-assist/src/lib/utils.test.ts
+++ b/packages/mcp-dev-assist/src/lib/utils.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { toMarkdown, transformLinkToResource } from "./utils.js";
+import { toMarkdown, toAbsoluteUrl } from "./utils.js";
 
 describe("toMarkdown", () => {
 	it("should convert html to markdown", async () => {
@@ -203,7 +203,7 @@ describe("toMarkdown", () => {
 				new URL("https://developers.google.com"),
 			);
 			await expect(markdown).resolves.toMatchInlineSnapshot(
-				`"[foo](docs://developers.google.com/foo)"`,
+				`"[foo](https://developers.google.com/foo)"`,
 			);
 		});
 		describe("transformLinkToResource", () => {
@@ -216,29 +216,33 @@ describe("toMarkdown", () => {
 				["mailto:foo@example.com", DGC, "mailto:foo@example.com"],
 				["tel:+123456789", DGC, "tel:+123456789"],
 				["ftp://example.com", DGC, "ftp://example.com"],
-				["foo", DGC, "docs://developers.google.com/foo"],
-				["foo/with/path", DGC, "docs://developers.google.com/foo/with/path"],
-				["/foo", DGC, "docs://developers.google.com/foo"],
-				["./foo", DGC, "docs://developers.google.com/foo"],
+				["foo", DGC, "https://developers.google.com/foo"],
+				["foo/with/path", DGC, "https://developers.google.com/foo/with/path"],
+				["/foo", DGC, "https://developers.google.com/foo"],
+				["./foo", DGC, "https://developers.google.com/foo"],
 				[
 					"./foo",
 					new URL("/baz/bar", DGC),
-					"docs://developers.google.com/baz/foo",
+					"https://developers.google.com/baz/foo",
 				],
 				[
 					"../foo",
 					new URL("/baz/bar", DGC),
-					"docs://developers.google.com/foo",
+					"https://developers.google.com/foo",
 				],
 				["/foo", EXAMPLE, "https://example.com/foo"],
-				["//developers.google.com", DGC, "docs://developers.google.com/"],
-				["http://developers.google.com", DGC, "docs://developers.google.com/"],
-				["https://developers.google.com", DGC, "docs://developers.google.com/"],
+				["//developers.google.com", DGC, "https://developers.google.com/"],
+				["http://developers.google.com", DGC, "http://developers.google.com/"],
+				[
+					"https://developers.google.com",
+					DGC,
+					"https://developers.google.com/",
+				],
 				["//example.com", EXAMPLE, "https://example.com/"],
 				["http://example.com", EXAMPLE, "http://example.com/"],
 				["https://example.com", EXAMPLE, "https://example.com/"],
 			])("should transform '%s' to '%s'", (url, contentUrl, expected) => {
-				expect(transformLinkToResource(url, contentUrl)).toBe(expected);
+				expect(toAbsoluteUrl(url, contentUrl)).toBe(expected);
 			});
 		});
 	});

--- a/packages/mcp-dev-assist/src/lib/utils.ts
+++ b/packages/mcp-dev-assist/src/lib/utils.ts
@@ -24,7 +24,6 @@ import remarkStringify from "remark-stringify";
 import { unified } from "unified";
 import { remove } from "unist-util-remove";
 import { visit } from "unist-util-visit";
-import { getResourceUri } from "./read.js";
 
 /**
  * Converts HTML to Markdown.
@@ -67,7 +66,7 @@ export async function toMarkdown(
 		.use(() => {
 			return (tree) => {
 				visit(tree, "link", (node: MDast.Link) => {
-					node.url = transformLinkToResource(node.url, contentUrl);
+					node.url = toAbsoluteUrl(node.url, contentUrl);
 				});
 			};
 		})
@@ -101,7 +100,7 @@ function isParagraph(node: MDast.Node): node is MDast.Paragraph {
 	return node.type === "paragraph";
 }
 
-export function transformLinkToResource(url: string, contentUrl: URL): string {
+export function toAbsoluteUrl(url: string, contentUrl: URL): string {
 	// Immediately return empty strings or pure fragment identifiers
 	if (url === "" || url.startsWith("#")) {
 		return url;
@@ -136,12 +135,5 @@ export function transformLinkToResource(url: string, contentUrl: URL): string {
 		return url; // Return the original URL for non-HTTP/S protocols
 	}
 
-	try {
-		return getResourceUri(absoluteUrl);
-	} catch (error) {
-		console.error(
-			`Failed to get resource URI for: "${absoluteUrl.href}". Error: ${error}`,
-		);
-		return absoluteUrl.href; // Return the resolved absolute URL if getResourceUri fails
-	}
+	return absoluteUrl.href;
 }


### PR DESCRIPTION
Resources have a low usage rate. Simplify to just use `https` protocol.